### PR TITLE
Google Photos implementation (unlimited storage)

### DIFF
--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -35,7 +35,7 @@ class ArloGooglePhotos:
         while True:
             self._get_videos()
             self._upload()
-            if not up_to_date:
+            if not self.up_to_date:
                 print(date.today().strftime('%Y-%m-%d %H:%M:%S') + ": Up to date! Leave this running for real-time backups.")
             self.up_to_update = True
             time.sleep(1)  # wait 1 second

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -32,16 +32,15 @@ class ArloGooglePhotos:
         print("Checking for new footage... This may take a minute")
         while True:
             self._get_videos()
-            self.last_update = date.today().strftime("%Y%m%d");
             self._upload()
-            time.sleep(60)  # re-check every minute
-            print("Upload complete. Snoozing for 1 minute... zzzzzzzzz")
+            time.sleep(1)  # wait 1 second
 
     def _get_videos(self):
         # Downloads videos from Arlo and uploads every 10 videos
         try:
             today = (date.today() - timedelta(days=0)).strftime("%Y%m%d")
             library = self.arlo.GetLibrary(self.last_update, today)
+            self.last_update = date.today().strftime("%Y%m%d");
             counter = 0  # count number of videos
             for recording in library:
 

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -22,6 +22,10 @@ class ArloGooglePhotos:
         self.last_update = (date.today() - timedelta(days=14)).strftime("%Y%m%d")
         self.videos_to_upload = []
 
+        # create folder "temp"
+        if not os.path.exists("temp"):
+            os.mkdir("temp")
+
     def run(self):
         """ Downloads arlo footage and uploads them to google photos"""
         while True:

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -61,7 +61,7 @@ class ArloGooglePhotos:
                 self.videos_to_upload.append('temp/' + videofilename)
 
                 # upload to g photos every 10 downloads
-                if counter % 2 == 0:
+                if counter % 10 == 0:
                     self._upload(10)
 
             self.last_update = today

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -33,6 +33,7 @@ class ArloGooglePhotos:
             self._get_videos()
             self._upload()
             time.sleep(60)  # re-check every minute
+            print("Upload complete. Snoozing for 1 minute... zzzzzzzzz")
 
     def _get_videos(self):
         # Downloads videos from Arlo and uploads every 10 videos
@@ -42,14 +43,14 @@ class ArloGooglePhotos:
             counter = 0  # count number of videos
             for recording in library:
 
-                # skip files that have been uploaded
-                if recording in self.photos_uploaded:
-                    pass
-
-                counter += 1
                 # Grab the recording name
                 videofilename = datetime.datetime.fromtimestamp(int(recording['name']) // 1000).strftime(
                     '%Y-%m-%d %H-%M-%S') + ' ' + recording['uniqueId'] + '.mp4'
+
+                # skip files that have been uploaded
+                if videofilename in self.photos_uploaded:
+                    continue
+                counter += 1
 
                 # Download video recording from Arlo
                 stream = self.arlo.StreamRecording(recording['presignedContentUrl'])

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -19,7 +19,7 @@ class ArloGooglePhotos:
         self.arlo = arlo
         # Get auth from file or log user in via browser
         self.googlePhotos = GooglePhotos()
-        self.last_update = (date.today() - timedelta(days=14)).strftime("%Y%m%d")
+        self.last_update = (date.today() - timedelta(days=30)).strftime("%Y%m%d")
         self.videos_to_upload = []
         self.photos_uploaded = self._load_uploaded_files()
 
@@ -29,8 +29,10 @@ class ArloGooglePhotos:
 
     def run(self):
         """ Downloads arlo footage and uploads them to google photos"""
+        print("Checking for new footage... This may take a minute")
         while True:
             self._get_videos()
+            self.last_update = date.today().strftime("%Y%m%d");
             self._upload()
             time.sleep(60)  # re-check every minute
             print("Upload complete. Snoozing for 1 minute... zzzzzzzzz")
@@ -65,8 +67,6 @@ class ArloGooglePhotos:
                 if counter % 10 == 0:
                     self._upload(10)
 
-            self.last_update = today
-
         except Exception as e:
             print(e)
 
@@ -95,7 +95,7 @@ class ArloGooglePhotos:
     def _load_uploaded_files(self):
         if os.path.exists('uploaded.json'):
             f = open('uploaded.json', 'r')
-            list = json.loads(f.read());
+            list = json.loads(f.read())
             return list
         else:
             return []

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -1,0 +1,241 @@
+from Arlo import Arlo
+from datetime import timedelta, date
+import datetime
+import time
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2.credentials import Credentials
+import json
+import os
+import logging
+
+
+class ArloGooglePhotos:
+
+    def __init__(self, arlo):
+        """ (Arlo, str, str) -> None
+        Start an Arlo Google Photos session
+        """
+        self.arlo = arlo
+        # Get auth from file or log user in via browser
+        self.googlePhotos = GooglePhotos()
+        self.last_update = (date.today() - timedelta(days=14)).strftime("%Y%m%d")
+        self.videos_to_upload = []
+
+    def run(self):
+        """ Downloads arlo footage and uploads them to google photos"""
+        while True:
+            self._get_videos()
+            self._upload()
+            time.sleep(60)  # re-check every minute
+
+    def _get_videos(self):
+        # Downloads videos from Arlo and uploads every 10 videos
+        try:
+            today = (date.today() - timedelta(days=0)).strftime("%Y%m%d")
+            library = self.arlo.GetLibrary(self.last_update, today)
+            counter = 0  # count number of videos
+            for recording in library:
+                counter += 1
+                # Grab the recording name
+                videofilename = datetime.datetime.fromtimestamp(int(recording['name']) // 1000).strftime(
+                    '%Y-%m-%d %H-%M-%S') + ' ' + recording['uniqueId'] + '.mp4'
+
+                # Download video recording from Arlo
+                stream = self.arlo.StreamRecording(recording['presignedContentUrl'])
+                with open('temp/' + videofilename, 'wb') as f:
+                    for chunk in stream:
+                        f.write(chunk)
+                    f.close()
+                print('Downloaded footage: ' + videofilename)
+                self.videos_to_upload.append('temp/' + videofilename)
+
+                # upload to g photos every 10 downloads
+                if counter % 10 == 0:
+                    self._upload(10)
+
+            self.last_update = today
+
+        except Exception as e:
+            print(e)
+
+    def _upload(self, num=None):
+        upload_list = self.videos_to_upload
+        if num:
+            upload_list = self.videos_to_upload[:num]
+
+        self.googlePhotos.upload_photos(upload_list,
+                                        'Arlo')
+
+        # Delete uploaded recordings
+        for file in upload_list:
+            if os.path.exists(file):
+                os.remove(file)
+                self.videos_to_upload.remove(file)
+
+
+class GooglePhotos:
+    """ Thanks to eshmu/gphotos-upload """
+
+    def __init__(self):
+        self.session = self.get_authorized_session('google_auth.json')
+
+    def auth(self, scopes):
+        flow = InstalledAppFlow.from_client_secrets_file(
+            'g_client.json',
+            scopes=scopes)
+
+        print('Opening OAuth')
+        credentials = flow.run_local_server(host='localhost',
+                                            port=8080,
+                                            authorization_prompt_message="",
+                                            success_message='Done. You may close this window.',
+                                            open_browser=True)
+
+        print('Logged into Google Photos')
+        return credentials
+
+    def get_authorized_session(self, auth_token_file):
+
+        scopes=['https://www.googleapis.com/auth/photoslibrary',
+                'https://www.googleapis.com/auth/photoslibrary.sharing']
+
+        cred = None
+
+        if auth_token_file:
+            try:
+                cred = Credentials.from_authorized_user_file(auth_token_file, scopes)
+            except OSError as err:
+                logging.debug("Error opening auth token file - {0}".format(err))
+            except ValueError:
+                logging.debug("Error loading auth tokens - Incorrect format")
+
+        if not cred:
+            cred = self.auth(scopes)
+
+        session = AuthorizedSession(cred)
+
+        if auth_token_file:
+            try:
+                self.save_cred(cred, auth_token_file)
+            except OSError as err:
+                logging.debug("Could not save auth tokens - {0}".format(err))
+
+        return session
+
+    def save_cred(self, cred, auth_file):
+
+        cred_dict = {
+            'token': cred.token,
+            'refresh_token': cred.refresh_token,
+            'id_token': cred.id_token,
+            'scopes': cred.scopes,
+            'token_uri': cred.token_uri,
+            'client_id': cred.client_id,
+            'client_secret': cred.client_secret
+        }
+
+        with open(auth_file, 'w') as f:
+            print(json.dumps(cred_dict), file=f)
+
+    # Generator to loop through all albums
+    def getAlbums(self, session, appCreatedOnly=False):
+
+        params = {
+                'excludeNonAppCreatedData': appCreatedOnly
+        }
+
+        while True:
+
+            albums = session.get('https://photoslibrary.googleapis.com/v1/albums', params=params).json()
+
+            logging.debug("Server response: {}".format(albums))
+
+            if 'albums' in albums:
+
+                for a in albums["albums"]:
+                    yield a
+
+                if 'nextPageToken' in albums:
+                    params["pageToken"] = albums["nextPageToken"]
+                else:
+                    return
+
+            else:
+                return
+
+    def create_or_retrieve_album(self, session, album_title):
+        # Find albums created by this app to see if one matches album_title
+        for a in self.getAlbums(session, True):
+            if a["title"].lower() == album_title.lower():
+                album_id = a["id"]
+                logging.info("Uploading into EXISTING photo album -- \'{0}\'".format(album_title))
+                return album_id
+
+    # No matches, create new album
+
+        create_album_body = json.dumps({"album":{"title": album_title}})
+        resp = session.post('https://photoslibrary.googleapis.com/v1/albums', create_album_body).json()
+
+        logging.debug("Server response: {}".format(resp))
+
+        if "id" in resp:
+            logging.info("Uploading into NEW photo album -- \'{0}\'".format(album_title))
+            return resp['id']
+        else:
+            logging.error("Could not find or create photo album '\{0}\'. Server Response: {1}".format(album_title, resp))
+            return None
+
+    def upload_photos(self, photo_file_list, album_name):
+        album_id = self.create_or_retrieve_album(self.session, album_name) if album_name else None
+
+        # interrupt upload if an upload was requested but could not be created
+        if album_name and not album_id:
+            return
+
+        self.session.headers["Content-type"] = "application/octet-stream"
+        self.session.headers["X-Goog-Upload-Protocol"] = "raw"
+
+        for photo_file_name in photo_file_list:
+
+            try:
+                photo_file = open(photo_file_name, mode='rb')
+                photo_bytes = photo_file.read()
+            except OSError as err:
+                logging.error("Could not read file \'{0}\' -- {1}".format(photo_file_name, err))
+                continue
+
+            self.session.headers["X-Goog-Upload-File-Name"] = os.path.basename(photo_file_name)
+
+            logging.info("Uploading photo -- \'{}\'".format(photo_file_name))
+
+            upload_token = self.session.post('https://photoslibrary.googleapis.com/v1/uploads', photo_bytes)
+
+            if (upload_token.status_code == 200) and (upload_token.content):
+
+                create_body = json.dumps({"albumId":album_id, "newMediaItems":[{"description":"","simpleMediaItem":{"uploadToken":upload_token.content.decode()}}]}, indent=4)
+
+                resp = self.session.post('https://photoslibrary.googleapis.com/v1/mediaItems:batchCreate', create_body).json()
+
+                logging.debug("Server response: {}".format(resp))
+
+                if "newMediaItemResults" in resp:
+                    status = resp["newMediaItemResults"][0]["status"]
+                    if status.get("code") and (status.get("code") > 0):
+                        logging.error("Could not add \'{0}\' to library -- {1}".format(os.path.basename(photo_file_name), status["message"]))
+                    else:
+                        logging.info("Added \'{}\' to library and album \'{}\' ".format(os.path.basename(photo_file_name), album_name))
+                else:
+                    logging.error("Could not add \'{0}\' to library. Server Response -- {1}".format(os.path.basename(photo_file_name), resp))
+
+            else:
+                logging.error("Could not upload \'{0}\'. Server Response - {1}".format(os.path.basename(photo_file_name), upload_token))
+
+            print('Uploaded: ' + photo_file_name)
+
+        try:
+            del(self.session.headers["Content-type"])
+            del(self.session.headers["X-Goog-Upload-Protocol"])
+            del(self.session.headers["X-Goog-Upload-File-Name"])
+        except KeyError:
+            pass

--- a/ArloGooglePhotos.py
+++ b/ArloGooglePhotos.py
@@ -23,7 +23,7 @@ class ArloGooglePhotos:
         self.videos_to_upload = []
         self._load_progress()
 
-        self.up_to_update = False
+        self.up_to_date = False
 
         # create folder "temp"
         if not os.path.exists("temp"):
@@ -37,7 +37,7 @@ class ArloGooglePhotos:
             self._upload()
             if not self.up_to_date:
                 print(date.today().strftime('%Y-%m-%d %H:%M:%S') + ": Up to date! Leave this running for real-time backups.")
-            self.up_to_update = True
+            self.up_to_date = True
             time.sleep(1)  # wait 1 second
 
     def _get_videos(self):

--- a/arlo_run_backup.py
+++ b/arlo_run_backup.py
@@ -1,0 +1,8 @@
+from ArloGooglePhotos import ArloGooglePhotos
+from Arlo import Arlo
+# Arlo auth
+USER = 'arlo username'
+PASS = 'arlo password'
+arlo = Arlo(USER, PASS)
+arlo_backup = ArloGooglePhotos(arlo)
+arlo_backup.run()

--- a/g_client.json
+++ b/g_client.json
@@ -1,0 +1,12 @@
+{
+    "installed":
+        {
+            "client_id":"CLIENT_ID",
+            "client_secret":"CLIENT_SECRET",
+
+            "auth_uri":"https://accounts.google.com/o/oauth2/auth",
+            "token_uri":"https://www.googleapis.com/oauth2/v3/token",
+            "auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs",
+            "redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]
+        }
+}


### PR DESCRIPTION
**Update (Running Headless):** Run the script once on your laptop to generate a session token. By default, It is saved as "google_auth.json". Then simply zip everything and scp (copy) the archive to your server. So you can run this on an old pc, pi or in the background of some personal prod server.

Happy holidays everyone! This PR allows you to automatically backup your Arlo footage to Google Photo's unlimited storage. It creates and uploads all footage to an album named "Arlo".

So my parents recently purchased an Arlo over the holidays and I was pretty bummed that the free tier only has a week of free storage. Not very useful if you're looking for patterns that occur over a week. My solution? Google Photos! After running this for some time, it's probably best to use a dedicated Google account until someone finds a way to exclude Arlo video from your other photos.

**Features**
- Uploads all existing footage to an album in your Google Photos called "Arlo"
- Checks for new footage every 60 seconds

**Setup**
1. You'll need a [Google Photos API](https://console.developers.google.com/apis/library/photoslibrary.googleapis.com) key and then add 'http://localhost:8080/' as one of the redirect URIs
2. Open up **g_client.json** and replace client_id and client_secret with your API keys
3. Use Python3

**Usage**
```
from ArloGooglePhotos import ArloGooglePhotos
from Arlo import Arlo

# Arlo auth
USER = 'arlo username'
PASS = 'arlo password'
arlo = Arlo(USER, PASS)

arlo_backup = ArloGooglePhotos(arlo)  # authenticate
arlo_backup.run()  # run backup
```

ArloGooglePhotos will launch your browser allowing you to login to Google. I haven't figured out how to do a headless OAuth2 authentication yet so I guess this will do for now. **Workaround available**

**Issues**
- If you lose internet, the script will crash
- **FIXED** If the script crashes, it will upload from newest -> oldest all over again
