### PR TITLE
Multiple type filter

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -828,14 +828,24 @@ class Arlo(object):
         """
         return self.request.put('https://my.arlo.com/hmsweb/users/locations/'+location_id, {'geoEnabled':active})
 
-    def GetDevices(self, device_type=None):
+    def GetDevices(self, device_type=None, device_state=None):
         """
         This method returns an array that contains the basestation, cameras, etc. and their metadata.
-        If you pass in a valid device type ('basestation', 'camera', etc.), this method will return an array of just those devices that match that type.
+        If you pass in a valid device type, as a string or a list, this method will return an array of just those devices that match that type. An example would be ['basestation', 'camera']
+        If you pass in a valid device state, as a string or list, this method can also filter on the devices that match that state. An example would be ['provisioned']
         """
-        devices = self.request.get('https://my.arlo.com/hmsweb/users/devices')
+        devices = self.request.get('https://arlo.netgear.com/hmsweb/users/devices')
         if device_type:
-            return [ device for device in devices if device['deviceType'] == device_type]
+            if not isinstance(device_type,list):
+                device_type = [device_type]
+
+            devices = [ device for device in devices if device['deviceType'] in device_type]
+
+        if device_state:
+            if not isinstance(device_state,list):
+                device_state = [device_state]
+
+            devices = [ device for device in devices if device.get("state") in device_state]
 
         return devices
 

--- a/arlo.py
+++ b/arlo.py
@@ -828,11 +828,11 @@ class Arlo(object):
         """
         return self.request.put('https://my.arlo.com/hmsweb/users/locations/'+location_id, {'geoEnabled':active})
 
-    def GetDevices(self, device_type=None, device_state=None):
+    def GetDevices(self, device_type=None, filter_provisioned=None):
         """
         This method returns an array that contains the basestation, cameras, etc. and their metadata.
         If you pass in a valid device type, as a string or a list, this method will return an array of just those devices that match that type. An example would be ['basestation', 'camera']
-        If you pass in a valid device state, as a string or list, this method can also filter on the devices that match that state. An example would be ['provisioned']
+        To filter provisioned or unprovisioned devices pass in a True/False value for filter_provisioned. By default both types are returned. 
         """
         devices = self.request.get('https://arlo.netgear.com/hmsweb/users/devices')
         if device_type:
@@ -841,12 +841,12 @@ class Arlo(object):
 
             devices = [ device for device in devices if device['deviceType'] in device_type]
 
-        if device_state:
-            if not isinstance(device_state,list):
-                device_state = [device_state]
-
-            devices = [ device for device in devices if device.get("state") in device_state]
-
+        if filter_provisioned != None:
+            if filter_provisioned:
+                devices = [ device for device in devices if device.get("state") == 'provisioned']
+            else:
+                devices = [ device for device in devices if device.get("state") != 'provisioned']
+                
         return devices
 
     def GetDeviceSupport(self):

--- a/arlo.py
+++ b/arlo.py
@@ -834,7 +834,7 @@ class Arlo(object):
         If you pass in a valid device type, as a string or a list, this method will return an array of just those devices that match that type. An example would be ['basestation', 'camera']
         To filter provisioned or unprovisioned devices pass in a True/False value for filter_provisioned. By default both types are returned. 
         """
-        devices = self.request.get('https://arlo.netgear.com/hmsweb/users/devices')
+        devices = self.request.get('https://my.arlo.com/hmsweb/users/devices')
         if device_type:
             if not isinstance(device_type,list):
                 device_type = [device_type]

--- a/arlo.py
+++ b/arlo.py
@@ -836,12 +836,9 @@ class Arlo(object):
         """
         devices = self.request.get('https://my.arlo.com/hmsweb/users/devices')
         if device_type:
-            if not isinstance(device_type,list):
-                device_type = [device_type]
-
             devices = [ device for device in devices if device['deviceType'] in device_type]
 
-        if filter_provisioned != None:
+        if filter_provisioned is not None:
             if filter_provisioned:
                 devices = [ device for device in devices if device.get("state") == 'provisioned']
             else:


### PR DESCRIPTION
As discussed in #125 

This will allow for filtering on multiple device types in a single GetDevices call by passing in a list of types. A string is still acceptable to maintain backwards compatibility. 

Filtering on provisioned or unprovided devices can be done by passing in a True/False value. Default (None) will do no filtering on the state of the device. This part of the code isn't quite as clean as if the user could specify a state string to filter on. However, I think it's unlikely users will be easily aware of the exact state values to pass in. The True/False value makes it easier on the end user. If you'd rather see this part done a different way let me know. 