### PR TITLE
60 seconds timeout on every connection added

### DIFF
--- a/request.py
+++ b/request.py
@@ -25,13 +25,13 @@ class Request(object):
 
     def _request(self, url, method='GET', params={}, headers={}, stream=False, raw=False):
         if method == 'GET':
-            r = self.session.get(url, params=params, headers=headers, stream=stream)
+            r = self.session.get(url, params=params, headers=headers, stream=stream, timeout=60)
             if stream is True:
                 return r
         elif method == 'PUT':
-            r = self.session.put(url, json=params, headers=headers)
+            r = self.session.put(url, json=params, headers=headers, timeout=60)
         elif method == 'POST':
-            r = self.session.post(url, json=params, headers=headers)
+            r = self.session.post(url, json=params, headers=headers, timeout=60)
 
         r.raise_for_status()
         body = r.json()


### PR DESCRIPTION
As you can see here https://2.python-requests.org/en/master/user/quickstart/#timeouts you need to put some timeout in your requests connection.

On my script that runs every 2 minutes on my VPS, sometimes (about 1 time a day) the process hangs for a long time (even hours).

This commit should fix it.

What do you think?