### PR TITLE
MFA: search for emails based on sender rather than subject

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -235,7 +235,7 @@ class Arlo(object):
             time.sleep(5)
             messages = service.users().messages().list(
                 userId='me',
-                q=f'Arlo one-time authentication code after:{request_start_time}'
+                q=f'from:do_not_reply@arlo.com after:{request_start_time}'
             ).execute()
 
             if messages['resultSizeEstimate'] == 0:


### PR DESCRIPTION
This allows searching for emails based on the sender 'do_not_reply@arlo.com', because the subject locale changes with the country you live in.

![](https://i.iya.at/chrome_vz51t9.png)