### PR TITLE
Support for the multiple verification emails (#177)

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -215,7 +215,7 @@ class Arlo(object):
             headers=headers,
             raw=True
         )
-        email_factor_id = next(i for i in factors_body['data']['items'] if i['factorType'] == 'EMAIL')['factorId']
+        email_factor_id = next(i for i in factors_body['data']['items'] if i['factorType'] == 'EMAIL' and i['factorRole'] == "PRIMARY")['factorId']
 
         # Start factor auth
         start_auth_body = self.request.post(


### PR DESCRIPTION
Adding suggestion by @samiveikko in #177 to handle login gracefully when user's primary email address is not the same as their Arlo web portal login address