### PR TITLE
feat(login) add interactive login

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -379,7 +379,6 @@ class Arlo(object):
                 headers=headers,
                 raw=True
             )
-            print(start_auth_body)
 
             if trusted:
                 token = start_auth_body['data']['accessToken']['token']

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ the License.
 
 ## Classes
 
-` class Arlo (username, password, google_credential_file=None) `
+` class Arlo (username, password, google_credential_file=None, interactive=False) `
 
 ### Class variables
 
@@ -514,6 +514,13 @@ Wnt9F7D82uN1f4cXXXXX-FMUsWF_6tMBqwn6DpzOaIB7ciJrnr2QJyKewbQouGM6",
 
 ` def LoginMFA(self, username, password, google_credential_file) `
 
+` def LoginMFAInteractive(self, username, password) `
+
+This is an interactive MFA dialog to help you log in. Ideally, you should
+already have set up a primary device and maybe some secondary ones. You'll
+be prompted with a list of them, to which you can choose to send the MFA code
+to (EMAIL), or a push notification (PUSH) to accept or deny.
+
 ` def Logout(self) `
 
 ` def Notify(self, basestation, body) `
@@ -935,6 +942,7 @@ This is an example of the json you would pass in the body: {
       * `HandleEvents`
       * `Login`
       * `LoginMFA`
+      * `LoginMFAInteractive`
       * `Logout`
       * `Notify`
       * `NotifyAndGetResponse`


### PR DESCRIPTION
I added a mostly working Interactive Login for MFA. I didn't want the automatic process of the script digging in my gmail for the email, etc. Using `interactive=True` will allow the user to choose which Factor to use.
**Email** = it will send the email the MFA code, the script will ask for it.
**Trusted Device** = it will send a push notification to approve/deny.

What is currently not working is the **Trust this current device** logic. But once that is figured out, the rest of the code _should_ be able to work.

To get a trusted device, you'll need to officially install the arlo app, log into it, then choose Trust Device from within the app. Then, this script should see it and prompt you with that option.

Example flow:
```
arlo = Arlo(USERNAME, PASSWORD, interactive=True)
# choose Trust Device phone during prompt
# Push Notification is sent to phone
# Approve (or Deny) the push notification
# script continues
```

