### PR TITLE
CVR playlist now requires the uniqueId

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -1755,4 +1755,4 @@ class Arlo(object):
 
     def GetCvrPlaylist(self, camera, fromDate, toDate):
         """ This function downloads a Cvr Playlist file for the period fromDate to toDate. """
-        return self.request.get(f'https://{self.BASE_URL}/hmsweb/users/devices/'+camera.get('deviceId')+'/playlist?fromDate='+fromDate+'&toDate='+toDate)
+        return self.request.get(f'https://{self.BASE_URL}/hmsweb/users/devices/'+camera.get('uniqueId')+'/playlist?fromDate='+fromDate+'&toDate='+toDate)


### PR DESCRIPTION
I have both CVR-enabled and regular cameras in my account and it works just fine. It was failing with error when deviceId was used.