### PR TITLE
fix cloudflare 403 with curl_cffi

### DIFF
--- a/arlo.py
+++ b/arlo.py
@@ -26,7 +26,7 @@ except ImportError:
 
 from request import Request
 from eventstream import EventStream
-    
+
 # Import all of the other stuff.
 from six import string_types, text_type
 from datetime import datetime
@@ -136,7 +136,9 @@ class Arlo(object):
         """
         self.username = username
         self.password = password
-        self.request = Request()
+
+        # start login with curl_cffi to address cloudflare client fingerprinting
+        self.request = Request(impersonate=True)
 
         headers = {
             'Access-Control-Request-Headers': 'content-type,source,x-user-device-id,x-user-device-name,x-user-device-type',
@@ -146,7 +148,7 @@ class Arlo(object):
             'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) Mobile/15B202 NETGEAR/v1 (iOS Vuezone)',
         }
         self.request.options(f'https://{self.AUTH_URL}/api/auth', headers=headers)
-        
+
         headers = {
             'DNT': '1',
             'schemaVersion': '1',
@@ -171,6 +173,8 @@ class Arlo(object):
         )
         headers['Authorization'] = body['token']
 
+        # create a new Request object with a session that can be used with sseclient
+        self.request = Request(impersonate=False)
         self.request.session.headers.update(headers)
 
         self.user_id = body['userId']
@@ -180,7 +184,9 @@ class Arlo(object):
         self.username = username
         self.password = password
         self.google_credentials = pickle.load(open(google_credential_file, 'rb'))
-        self.request = Request()
+
+        # start login with curl_cffi to address cloudflare client fingerprinting
+        self.request = Request(impersonate=True)
 
         # request MFA token
         request_start_time = int(time.time())
@@ -285,6 +291,8 @@ class Arlo(object):
             'Authorization': finish_auth_body['data']['token'].encode('utf-8'),
             'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) Mobile/15B202 NETGEAR/v1 (iOS Vuezone)',
         }
+        # create a new Request object with a session that can be used with sseclient
+        self.request = Request(impersonate=False)
         self.request.session.headers.update(headers)
         self.BASE_URL = 'myapi.arlo.com'
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url='https://github.com/jeffreydwalter/arlo',
     license='Apache Software License',
     include_package_data=True,
-    install_requires=['monotonic', 'requests', 'responses==0.10.15', 'urllib3==1.24', 'sseclient==0.0.22', 'PySocks', 'pickle-mixin', 'google-api-python-client', 'google-auth-oauthlib'],
+    install_requires=['monotonic', 'requests', 'responses==0.10.15', 'urllib3==1.24', 'sseclient==0.0.22', 'PySocks', 'pickle-mixin', 'google-api-python-client', 'google-auth-oauthlib', 'curl-cffi==0.5.7'],
     keywords=[
         'arlo',
         'camera',


### PR DESCRIPTION
Cloudflare frequently returns a 403 on the Arlo login, which to the best of my understanding is decided on client heuristics, i.e. if a client is determined with some confidence to _not_ be a browser, the request is blocked. One of the heuristics used is the TLS fingerprint of the client. The `curl_cffi` project aims to enable Python scripts to bypass this TLS fingerprinting check through creating TLS handshakes that are identical to a real Chrome browser. This is accomplished through the use of the `curl-impersonate` project, which compiles `curl` with the exact TLS/SSL libraries used by Chrome and Firefox.

We have seen reasonable success in using this option over `cloudscraper` in the Scrypted home automation project. A caveat is that `curl_cffi` exposes a `requests`-like API, but does not implement the full API; therefore, `curl_cffi` is only used for the initial login, and subsequent requests fall back on `requests` so `sseclient` can continue working. Arlo appears to be happy with just the token in the header, and performs no additional TLS fingerprinting checks after login succeeds.

Note that this is not tested comprehensively, since I do not use this version of the arlo library.

Fixes #204 